### PR TITLE
Fix key_sequence

### DIFF
--- a/data/entities/teleporters/teleporters.lua
+++ b/data/entities/teleporters/teleporters.lua
@@ -177,7 +177,7 @@ local hotkey =
   type = "custom-input",
   name = hotkey_name,
   linked_game_control = "focus-search",
-  key_sequence = "Control + F"
+  key_sequence = "CONTROL + F"
 }
 
 data:extend


### PR DESCRIPTION
> 14.651 Error ControlSettings.cpp:220: teleporter-focus-search (custom-input): unknown key_sequence: Control + F

It's look the wiki state key_sequence need to be with upper case