### PR TITLE
Setting for non interplanetary teleporters

### DIFF
--- a/locale/de/teleporters.cfg
+++ b/locale/de/teleporters.cfg
@@ -3,5 +3,15 @@ no-teleporters=Da ist kein Teleporter um dich zu einem anderen zu teleportieren.
 name-already-taken=Name bereits vergeben.
 name-teleporter=Teleporter Name
 teleporter-network=Teleporter Netzwerk
+cant-add-tag=Sie können keine Kartennotiz mit dem Teleporter-Symbol hinzufügen.
+cant-change-icon=Sie können das Symbol einer Teleporter-Kartennotiz nicht ändern.
+rename-teleporter=Teleport umbenennen
+gui-train-rename.perform-change=Änderung annehmen
 
 search=__CONTROL__focus-search__
+
+[mod-setting-name]
+teleport_everywhere=Teleportation zwischen Planeten erlauben
+
+[mod-setting-description]
+teleport_everywhere=Durch Deaktivierung dieser Option wird die Teleportation nur auf Teleporter auf dem aktuellen Planet beschränkt.

--- a/locale/en/teleporters.cfg
+++ b/locale/en/teleporters.cfg
@@ -6,4 +6,12 @@ teleporter-network=Teleporter network
 cant-add-tag=You can not add a chart tag with the teleporter icon.
 cant-change-icon=You can not modify a teleporter chart tags icon.
 rename-teleporter=Rename teleporter
+gui-train-rename.perform-change=Accept change
+
 search=__CONTROL__focus-search__
+
+[mod-setting-name]
+teleport_everywhere=Enable teleport across planets
+
+[mod-setting-description]
+teleport_everywhere=Disabling this option will restrict teleportation to only those teleporters located on your current surface.

--- a/locale/ru/teleporters.cfg
+++ b/locale/ru/teleporters.cfg
@@ -1,0 +1,17 @@
+teleporter=Телепорт
+no-teleporters=Нет доступных телепортов
+name-already-taken=Имя уже занято
+name-teleporter=Назвать телепорт
+teleporter-network=Сеть телепортов
+cant-add-tag=Вы не можете добавить метку на карте с иконкой телепорта.
+cant-change-icon=Вы не можете изменить иконку метки на карте телепорта.
+rename-teleporter=Переименовать телепорт
+gui-train-rename.perform-change=Применить
+
+search=__CONTROL__focus-search__
+
+[mod-setting-name]
+teleport_everywhere=Включить телепортацию между планетами
+
+[mod-setting-description]
+teleport_everywhere=Отключение этой опции ограничит использование телепортов только теми, которые находятся на текущей поверхности.

--- a/locale/zh-CN/teleporters.cfg
+++ b/locale/zh-CN/teleporters.cfg
@@ -5,6 +5,9 @@ name-teleporter=命名传送井
 teleporter-network=传送器网络
 cant-add-tag=你不能用传送井图标添加图表标签
 cant-change-icon=您不能修改传送井图表标签图标
+rename-teleporter=重命名传送井
+gui-train-rename.perform-change=接受更改
+
 search=__CONTROL__focus-search__
 
 [mod-name]
@@ -12,3 +15,9 @@ Teleporters=传送井
 
 [mod-description]
 Teleporters=添加高科技传送井
+
+[mod-setting-name]
+teleport_everywhere=启用行星之间的传送
+
+[mod-setting-description]
+teleport_everywhere=禁用此选项将限制只能使用位于您当前表面的传送井。

--- a/script/teleporters.lua
+++ b/script/teleporters.lua
@@ -206,8 +206,10 @@ local make_teleporter_gui = function(player, source)
 
   local sorted = {}
   local i = 1
+  local player_location = player.surface.name
   for name, teleporter in pairs (network) do
-    if teleporter.teleporter.valid then
+    local teleport_location = teleporter.teleporter.surface.planet.name
+    if teleporter.teleporter.valid and (settings.global["teleport_everywhere"].value or teleport_location == player_location) then
       sorted[i] = {name = name, teleporter = teleporter, unit_number = teleporter.teleporter.unit_number}
       i = i + 1
     else

--- a/script/teleporters.lua
+++ b/script/teleporters.lua
@@ -206,14 +206,14 @@ local make_teleporter_gui = function(player, source)
 
   local sorted = {}
   local i = 1
-  local player_location = player.surface.name
   for name, teleporter in pairs (network) do
-    local teleport_location = teleporter.teleporter.surface.planet.name
-    if teleporter.teleporter.valid and (settings.global["teleport_everywhere"].value or teleport_location == player_location) then
-      sorted[i] = {name = name, teleporter = teleporter, unit_number = teleporter.teleporter.unit_number}
-      i = i + 1
-    else
-      clear_teleporter_data(teleporter)
+    if teleporter.teleporter.valid then
+      if settings.global["teleport_everywhere"].value or teleporter.teleporter.surface.planet.name == player.surface.name then
+        sorted[i] = {name = name, teleporter = teleporter, unit_number = teleporter.teleporter.unit_number}
+        i = i + 1
+      else
+        clear_teleporter_data(teleporter)
+      end
     end
   end
 

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+    {
+        type = "bool-setting",
+        name = "teleport_everywhere",
+        setting_type = "runtime-global",
+        default_value = true
+    }
+})


### PR DESCRIPTION
I added setting `teleport_everywhere` with default true. if false, player can teleport only on his current planet. 
also added missing translation in given languages and added russian language.